### PR TITLE
fix: Get the CPU Instructions from TransactionData

### DIFF
--- a/src/stellar-plus/core/contract-engine/index.ts
+++ b/src/stellar-plus/core/contract-engine/index.ts
@@ -207,7 +207,8 @@ export class ContractEngine extends SorobanTransactionProcessor {
     const eventsSize = events?.reduce((accumulator, currentValue) => accumulator + currentValue, 0)
 
     return {
-      cpuInstructions: Number(simulated.cost?.cpuInsns),
+      // cpuInstructions: Number(simulated.cost?.cpuInsns),
+      cpuInstructions: Number(sorobanTransactionData?.resources().instructions()),
       ram: Number(simulated.cost?.memBytes),
       minResourceFee: Number(simulated.minResourceFee),
       ledgerReadBytes: sorobanTransactionData?.resources().readBytes(),


### PR DESCRIPTION
Change the source of the CPU instructions data from `cost` to `transactionData`, since the second one has more accurate data on final costs.