### PR TITLE
fix: add validation in extract result Xdr function

### DIFF
--- a/src/stellar-plus/error/helpers/result-meta-xdr.test.ts
+++ b/src/stellar-plus/error/helpers/result-meta-xdr.test.ts
@@ -1,0 +1,98 @@
+import Stellar from '@stellar/stellar-sdk';
+import { extractSorobanResultXdrOpErrorCode } from './result-meta-xdr';
+
+jest.mock('@stellar/stellar-sdk');
+
+describe('extractSorobanResultXdrOpErrorCode', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    Stellar.xdr.TransactionResult = {
+      fromXDR: jest.fn(),
+    }
+  })
+
+  it('should extract op error code from XDR string', () => {
+    const mockResultXdrObject = {
+      result: () => ({
+        results: () => [{
+          tr: () => ({
+            value: () => ({
+              switch: () => ({
+                name: 'opErrorCode',
+              }),
+            }),
+          }),
+        }],
+      }),
+    };
+
+    Stellar.xdr.TransactionResult.fromXDR.mockReturnValueOnce(mockResultXdrObject);
+
+    const result = extractSorobanResultXdrOpErrorCode('base64EncodedXDR');
+
+    expect(result).toBe('opErrorCode');
+    expect(Stellar.xdr.TransactionResult.fromXDR).toHaveBeenCalledWith('base64EncodedXDR', 'base64');
+  });
+
+  it('should handle XDR object with result method', () => {
+    const mockResultXdrObject = {
+      result: jest.fn(() => ({
+        results: jest.fn(() => [{
+          tr: jest.fn(() => ({
+            value: jest.fn(() => ({
+              switch: jest.fn(() => ({
+                name: 'opErrorCode',
+              })),
+            })),
+          })),
+        }]),
+      })),
+    };
+
+    const result = extractSorobanResultXdrOpErrorCode(<any>mockResultXdrObject);
+
+    expect(result).toBe('opErrorCode');
+    expect(mockResultXdrObject.result).toHaveBeenCalled();
+  });
+
+  it('should handle XDR object with result.switch method', () => {
+    const mockResultXdrObject = {
+      result: jest.fn(() => ({
+        switch: jest.fn(() => ({
+          name: 'opErrorCode',
+        })),
+      })),
+    };
+
+    const result = extractSorobanResultXdrOpErrorCode(<any>mockResultXdrObject);
+
+    expect(result).toBe('opErrorCode');
+    expect(mockResultXdrObject.result).toHaveBeenCalled();
+  });
+
+  it('should handle XDR object with missing results or switch methods', () => {
+    const result = extractSorobanResultXdrOpErrorCode(<any>{});
+
+    expect(result).toBe('not_found');
+  });
+
+  it('should handle decoding errors', () => {
+    const mockResultXdrObject = {
+      result: () => {
+        throw new Error('Decoding error');
+      },
+    };
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => { });
+
+    const result = extractSorobanResultXdrOpErrorCode(<any>mockResultXdrObject);
+
+    expect(result).toBe('fail_in_decode_xdr');
+    expect(consoleSpy).toHaveBeenCalledWith('Fail in decode xdr: %s, Error: %s', mockResultXdrObject, expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/stellar-plus/error/helpers/result-meta-xdr.ts
+++ b/src/stellar-plus/error/helpers/result-meta-xdr.ts
@@ -5,7 +5,25 @@ export const extractSorobanResultXdrOpErrorCode = (resultXdr: xdr.TransactionRes
     const resultXdrObject = xdr.TransactionResult.fromXDR(resultXdr, 'base64')
     return resultXdrObject.result().results()[0].tr().value().switch().name
   }
-  return resultXdr.result().results()[0].tr().value().switch().name
+  try {
+    if (resultXdr.result?.().results !== undefined
+      && typeof resultXdr.result?.().results === 'function') {
+      return resultXdr.result?.().results?.()[0].tr?.().value?.().switch?.().name
+    }
+  } catch (error) {
+    console.log("Xdr don't have results: %s", error)
+  }
+  try {
+    if (resultXdr.result?.().switch !== undefined
+      && typeof resultXdr.result?.().switch === 'function') {
+      return resultXdr.result?.().switch?.().name
+    }
+  }
+  catch (error) {
+    console.log('Fail in decode xdr: %s, Error: %s', resultXdr, error)
+    return "fail_in_decode_xdr"
+  }
+  return "not_found"
 }
 
 export enum SorobanOpCodes {


### PR DESCRIPTION
For some `TransactionResult` error response, the `results` function is not set and `extractSorobanResultXdrOpErrorCode` is unable to decode, for example:
**XDR response:**
```typescript  
ChildStruct {
  _attributes: {
    feeCharged: Hyper { _value: 324558n },
    result: ChildUnion {
      _switch: [ChildEnum],
      _arm: 'innerResultPair',
      _armType: [Function],
      _value: [ChildStruct]
    },
    ext: ChildUnion {
      _switch: 0,
      _arm: [class Void extends XdrPrimitiveType],
      _armType: [class Void extends XdrPrimitiveType],
      _value: undefined
    }
  }
}
```

In this case, `extractSorobanResultXdrOpErrorCode` respond with unknown code.
To fix this, was add a validation to know if `results` function is set.