### PR TITLE
feat: add export to channel accounts plugin for classic

### DIFF
--- a/src/stellar-plus/utils/pipeline/plugins/classic-transaction/channel-accounts/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/classic-transaction/channel-accounts/index.ts
@@ -1,0 +1,18 @@
+import {
+  ClassicTransactionPipelineInput,
+  ClassicTransactionPipelineOutput,
+  ClassicTransactionPipelineType,
+} from 'stellar-plus/core/pipelines/classic-transaction/types'
+
+import { BaseChannelAccountsPlugin } from '../../soroban-transaction/channel-accounts'
+import { ChannelAccountsPluginConstructorArgs } from '../../soroban-transaction/channel-accounts/types'
+
+export class ClassicChannelAccountsPlugin extends BaseChannelAccountsPlugin<
+  ClassicTransactionPipelineInput,
+  ClassicTransactionPipelineOutput,
+  ClassicTransactionPipelineType
+> {
+  constructor(args: ChannelAccountsPluginConstructorArgs) {
+    super(ClassicTransactionPipelineType.id, args.channels)
+  }
+}

--- a/src/stellar-plus/utils/pipeline/plugins/classic-transaction/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/classic-transaction/index.ts
@@ -1,0 +1,5 @@
+import { ClassicChannelAccountsPlugin } from './channel-accounts'
+
+export const classicTransactionPlugins = {
+  channelAccounts: ClassicChannelAccountsPlugin,
+}

--- a/src/stellar-plus/utils/pipeline/plugins/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/index.ts
@@ -1,3 +1,4 @@
+import { classicTransactionPlugins } from './classic-transaction'
 import { genericPlugins } from './generic'
 import { filterPluginsByName, filterPluginsByType, filterPluginsByTypes } from './helpers'
 import { simulateTransactionPlugins } from './simulate-transaction'
@@ -7,6 +8,7 @@ import { submitTransactionPlugins } from './submit-transaction'
 
 export const plugins = {
   generic: genericPlugins,
+  classicTransaction: classicTransactionPlugins,
   simulateTransaction: simulateTransactionPlugins,
   sorobanGetTransaction: sorobanGetTransactionPlugins,
   sorobanTransaction: sorobanTransactionPlugins,

--- a/src/stellar-plus/utils/pipeline/plugins/soroban-transaction/channel-accounts/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/soroban-transaction/channel-accounts/index.ts
@@ -1,10 +1,5 @@
 import { AccountHandler } from 'stellar-plus/account'
 import {
-  ClassicTransactionPipelineInput,
-  ClassicTransactionPipelineOutput,
-  ClassicTransactionPipelineType,
-} from 'stellar-plus/core/pipelines/classic-transaction/types'
-import {
   SorobanTransactionPipelineInput,
   SorobanTransactionPipelineOutput,
   SorobanTransactionPipelineType,
@@ -17,7 +12,9 @@ import {
   InputType,
 } from 'stellar-plus/utils/pipeline/plugins/soroban-transaction/channel-accounts/types'
 
-class ChannelAccountsPlugin<Input extends InputType, Output, Type> implements BeltPluginType<Input, Output, Type> {
+export class BaseChannelAccountsPlugin<Input extends InputType, Output, Type>
+  implements BeltPluginType<Input, Output, Type>
+{
   readonly type
   readonly name = 'ChannelAccountsPlugin'
   private freeChannels: AccountHandler[]
@@ -147,17 +144,7 @@ class ChannelAccountsPlugin<Input extends InputType, Output, Type> implements Be
   }
 }
 
-export class ClassicChannelAccountsPlugin extends ChannelAccountsPlugin<
-  ClassicTransactionPipelineInput,
-  ClassicTransactionPipelineOutput,
-  ClassicTransactionPipelineType
-> {
-  constructor(args: ChannelAccountsPluginConstructorArgs) {
-    super(ClassicTransactionPipelineType.id, args.channels)
-  }
-}
-
-export class SorobanChannelAccountsPlugin extends ChannelAccountsPlugin<
+export class SorobanChannelAccountsPlugin extends BaseChannelAccountsPlugin<
   SorobanTransactionPipelineInput,
   SorobanTransactionPipelineOutput,
   SorobanTransactionPipelineType


### PR DESCRIPTION
Added to 'classicTransaction' pipeline plugins export to: `StellarPlus.Utils.Plugins`, including a specific export for `ChannelAccountsPlugin` for Classic.