### PR TITLE
Feat verify signature

### DIFF
--- a/src/stellar-plus/account/account-handler/default/errors.ts
+++ b/src/stellar-plus/account/account-handler/default/errors.ts
@@ -5,6 +5,7 @@ export enum DefaultAccountHandlerErrorCodes {
   DAH001 = 'DAH001',
   DAH002 = 'DAH002',
   DAH003 = 'DAH003',
+  DAH004 = 'DAH004',
 }
 
 const failedToLoadSecretKeyError = (error?: Error): StellarPlusError => {
@@ -55,8 +56,21 @@ const failedToSignAuthorizationEntryError = (
   })
 }
 
+const failedToSignDataError = (error?: Error): StellarPlusError => {
+  return new StellarPlusError({
+    code: DefaultAccountHandlerErrorCodes.DAH004,
+    message: 'Failed to sign data!',
+    source: 'DefaultAccountHandler',
+    details: 'The data could not be signed. Review the secret key.',
+    meta: {
+      error,
+    },
+  })
+}
+
 export const DAHError = {
   failedToLoadSecretKeyError,
   failedToSignTransactionError,
   failedToSignAuthorizationEntryError,
+  failedToSignDataError,
 }

--- a/src/stellar-plus/account/account-handler/default/index.ts
+++ b/src/stellar-plus/account/account-handler/default/index.ts
@@ -104,4 +104,18 @@ export class DefaultAccountHandlerClient extends AccountBase implements DefaultA
       )
     }
   }
+
+  /**
+   *
+   * @param {Buffer} data - The data to sign.
+   * @returns {Buffer} The signature of the data.
+   */
+  public signData(data: Buffer): Buffer {
+    try {
+      const keypair = Keypair.fromSecret(this.secretKey)
+      return keypair.sign(data)
+    } catch (e) {
+      throw DAHError.failedToSignDataError(e as Error)
+    }
+  }
 }

--- a/src/stellar-plus/account/account-handler/default/index.unit.test.ts
+++ b/src/stellar-plus/account/account-handler/default/index.unit.test.ts
@@ -102,6 +102,16 @@ describe('DefaultAccountHandler', () => {
         TESTNET_CONFIG.networkPassphrase
       )
     })
+
+    it('should sign data with its secret key', () => {
+      const keypair = Keypair.random()
+      const dah = new DefaultAccountHandlerClient({ networkConfig: TESTNET_CONFIG, secretKey: keypair.secret() })
+      const data = Buffer.from('Mocked Data')
+
+      const signature = dah.signData(data)
+
+      expect(dah.verifySignature(data, signature)).toBe(true)
+    })
   })
 
   describe('Getters', () => {
@@ -174,6 +184,15 @@ describe('DefaultAccountHandler', () => {
           123,
           TESTNET_CONFIG.networkPassphrase
         )
+      )
+    })
+
+    it('should throw an error if data cannot be signed', () => {
+      const keypair = Keypair.random()
+      const dah = new DefaultAccountHandlerClient({ networkConfig: TESTNET_CONFIG, secretKey: keypair.secret() })
+
+      expect(() => dah.signData(null as unknown as Buffer)).toThrow(
+        DAHError.failedToSignDataError(new Error('Mocked error'))
       )
     })
   })

--- a/src/stellar-plus/account/base/index.ts
+++ b/src/stellar-plus/account/base/index.ts
@@ -1,4 +1,4 @@
-import { Horizon } from '@stellar/stellar-sdk'
+import { Horizon, Keypair } from '@stellar/stellar-sdk'
 import axios from 'axios'
 
 import { ABError } from 'stellar-plus/account/base/errors'
@@ -80,6 +80,17 @@ export class AccountBase implements AccountBaseType {
     } catch (error) {
       throw ABError.failedToLoadBalances(error as Error)
     }
+  }
+
+  /**
+   *
+   * @param {Buffer} data - The data to sign.
+   * @param {Buffer} signature - The signature to verify.
+   * @returns {boolean} True if the signature is valid, false otherwise.
+   */
+  public verifySignature(data: Buffer, signature: Buffer): boolean {
+    const keypair = Keypair.fromPublicKey(this.publicKey)
+    return keypair.verify(data, signature)
   }
 
   /**

--- a/src/stellar-plus/account/base/index.unit.test.ts
+++ b/src/stellar-plus/account/base/index.unit.test.ts
@@ -7,6 +7,8 @@ import { ABError } from 'stellar-plus/account/base/errors'
 import { AxiosErrorTypes } from 'stellar-plus/error/helpers/axios'
 import { HorizonHandler } from 'stellar-plus/horizon/types'
 import { TestNet } from 'stellar-plus/network'
+import { DefaultAccountHandlerClient } from '../account-handler/default'
+import { Keypair } from '@stellar/stellar-sdk'
 
 jest.mock('axios', () => {
   const originalModule = jest.requireActual('axios')
@@ -93,6 +95,27 @@ describe('Base Account Handler', () => {
 
       expect(balances).toBe(mockedBalances)
       expect(mockedLoadAccount).toHaveBeenCalledExactlyOnceWith(MOCKED_PK)
+    })
+
+    it('verify if a signature is valid', () => {
+      const keypair = Keypair.random()
+      const dah = new DefaultAccountHandlerClient({ networkConfig: TESTNET_CONFIG, secretKey: keypair.secret() })
+      const data = Buffer.from('Mocked Data')
+
+      const signature = dah.signData(data)
+
+      expect(dah.verifySignature(data, signature)).toBe(true)
+    })
+
+    it('verify if a signature is not valid', () => {
+      const keypair = Keypair.random()
+      const dah = new DefaultAccountHandlerClient({ networkConfig: TESTNET_CONFIG, secretKey: keypair.secret() })
+      const secondDah = new DefaultAccountHandlerClient({ networkConfig: TESTNET_CONFIG })
+      const data = Buffer.from('Mocked Data')
+
+      const signature = dah.signData(data)
+
+      expect(secondDah.verifySignature(data, signature)).toBe(false)
     })
   })
 


### PR DESCRIPTION
Added the following features

Default Account Handler:
- `signData` : can sign any Buffer of data and returns a Buffer signature

Base Account:
- `verifySignature`: Verify any Buffer of data to have been signed by the account public key and to match the provided data
