### PR TITLE
feat: standardize verbose invocations

### DIFF
--- a/src/stellar-plus/asset/classic/index.unit.test.ts
+++ b/src/stellar-plus/asset/classic/index.unit.test.ts
@@ -283,6 +283,7 @@ describe('Classic Asset Handler', () => {
       expect(spyExecute).toHaveBeenCalledExactlyOnceWith({
         txInvocation: args as TransactionInvocation,
         operations: ['paymentOp'],
+        options: {},
       })
     })
 
@@ -341,6 +342,7 @@ describe('Classic Asset Handler', () => {
           signers: [mockedUserAccountHandler, mockedIssuerAccountHandler],
         } as TransactionInvocation,
         operations: ['paymentOp'],
+        options: {},
       })
     })
 
@@ -366,6 +368,7 @@ describe('Classic Asset Handler', () => {
       expect(spyExecute).toHaveBeenCalledExactlyOnceWith({
         txInvocation: args as TransactionInvocation,
         operations: ['changeTrustOp'],
+        options: {},
       })
     })
 
@@ -396,6 +399,7 @@ describe('Classic Asset Handler', () => {
           signers: [mockedUserAccountHandler, mockedIssuerAccountHandler],
         } as TransactionInvocation,
         operations: ['changeTrustOp', 'paymentOp'],
+        options: {},
       })
     })
   })

--- a/src/stellar-plus/asset/classic/types.ts
+++ b/src/stellar-plus/asset/classic/types.ts
@@ -1,8 +1,10 @@
-import { Horizon } from '@stellar/stellar-sdk'
-
 import { AccountHandler } from 'stellar-plus/account/account-handler/types'
 import { AssetType, AssetTypes } from 'stellar-plus/asset/types'
-import { ClassicTransactionPipelineOptions } from 'stellar-plus/core/pipelines/classic-transaction/types'
+import {
+  ClassicTransactionPipelineInput,
+  ClassicTransactionPipelineOptions,
+  ClassicTransactionPipelineOutput,
+} from 'stellar-plus/core/pipelines/classic-transaction/types'
 import { TransactionInvocation } from 'stellar-plus/core/types'
 import { NetworkConfig } from 'stellar-plus/types'
 
@@ -31,18 +33,18 @@ export type ClassicTokenInterfaceManagement = {
     args: {
       to: string
       amount: number
-    } & TransactionInvocation
-  ) => Promise<Horizon.HorizonApi.SubmitTransactionResponse>
+    } & BaseInvocation
+  ) => Promise<ClassicTransactionPipelineOutput>
 
-  setFlags: (
-    args: { controlFlags: ControlFlags } & TransactionInvocation
-  ) => Promise<Horizon.HorizonApi.SubmitTransactionResponse>
+  setFlags: (args: { controlFlags: ControlFlags } & BaseInvocation) => Promise<ClassicTransactionPipelineOutput>
 }
 
 export type ClassicTokenInterfaceUser = {
   balance: (id: string) => Promise<number>
-  transfer: (args: { from: string; to: string; amount: number } & TransactionInvocation) => Promise<void>
-  burn: (args: { from: string; amount: number } & TransactionInvocation) => Promise<void>
+  transfer: (
+    args: { from: string; to: string; amount: number } & BaseInvocation
+  ) => Promise<ClassicTransactionPipelineOutput>
+  burn: (args: { from: string; amount: number } & BaseInvocation) => Promise<ClassicTransactionPipelineOutput>
   decimals: () => Promise<number>
   name: () => Promise<string>
   symbol: () => Promise<string>
@@ -50,8 +52,9 @@ export type ClassicTokenInterfaceUser = {
 
 export type ClassicUtils = {
   addTrustlineAndMint: (
-    args: { to: string; amount: number } & TransactionInvocation
-  ) => Promise<Horizon.HorizonApi.SubmitTransactionResponse>
+    args: { to: string; amount: number } & BaseInvocation
+  ) => Promise<ClassicTransactionPipelineOutput>
+  addTrustline: (args: { to: string } & BaseInvocation) => Promise<ClassicTransactionPipelineOutput>
 }
 
 export type ControlFlags = {
@@ -59,4 +62,8 @@ export type ControlFlags = {
   authorizationRevocable?: boolean
   clawbackEnabled?: boolean
   authorizationImmutable?: boolean
+}
+
+export type BaseInvocation = TransactionInvocation & {
+  options?: ClassicTransactionPipelineInput['options']
 }

--- a/src/stellar-plus/core/contract-engine/index.unit.test.ts
+++ b/src/stellar-plus/core/contract-engine/index.unit.test.ts
@@ -191,7 +191,7 @@ describe('ContractEngine', () => {
         },
       })
 
-      await expect(contractEngine.uploadWasm(MOCKED_TX_INVOCATION)).resolves.toBeUndefined()
+      await expect(contractEngine.uploadWasm(MOCKED_TX_INVOCATION)).resolves.toBeDefined()
       expect(contractEngine.getWasm()).toEqual(MOCKED_WASM_FILE)
     })
 
@@ -216,7 +216,7 @@ describe('ContractEngine', () => {
         },
       })
 
-      await expect(contractEngine.deploy(MOCKED_TX_INVOCATION)).resolves.toBeUndefined()
+      await expect(contractEngine.deploy(MOCKED_TX_INVOCATION)).resolves.toBeDefined()
       expect(contractEngine.getContractId()).toEqual(MOCKED_CONTRACT_ID)
     })
   })
@@ -514,7 +514,7 @@ describe('ContractEngine', () => {
 
       await expect(
         contractEngine.wrapAndDeployClassicAsset({ asset: MOCKED_STELLAR_ASSET, ...MOCKED_TX_INVOCATION })
-      ).resolves.toBeUndefined()
+      ).resolves.toBeDefined()
 
       expect(contractEngine.getContractId()).toEqual(MOCKED_CONTRACT_ID)
     })

--- a/src/stellar-plus/core/contract-engine/types.ts
+++ b/src/stellar-plus/core/contract-engine/types.ts
@@ -23,6 +23,10 @@ export type Options = {
   sorobanTransactionPipeline?: SorobanTransactionPipelineOptions
 }
 
+export type BaseInvocation = TransactionInvocation & {
+  options?: SorobanTransactionPipelineInput['options']
+}
+
 export type TransactionResources = {
   cpuInstructions?: number
   ram?: number
@@ -48,15 +52,7 @@ export type SorobanSimulateArgs<T> = {
   options?: SorobanTransactionPipelineInput['options']
 }
 
-export type SorobanUploadArgs = TransactionInvocation & {
-  wasm: Buffer
-}
-
-export type SorobanDeployArgs = TransactionInvocation & {
-  wasmHash: string
-}
-
-export type WrapClassicAssetArgs = TransactionInvocation & {
+export type WrapClassicAssetArgs = BaseInvocation & {
   asset: StellarAsset
 }
 
@@ -65,7 +61,7 @@ export type ExtendFootprintTTLArgs = TransactionInvocation & {
   footprint: xdr.LedgerFootprint
 }
 
-export type RestoreFootprintArgs = TransactionInvocation &
+export type RestoreFootprintArgs = BaseInvocation &
   (RestoreFootprintWithLedgerKeys | RestoreFootprintWithRestorePreamble)
 
 export type RestoreFootprintWithLedgerKeys = {


### PR DESCRIPTION
Adjusted a few surface layer features to standardize invocation-related responses, allowing pipeline options to be used within single invocations in that context and providing the entire output.