### PR TITLE
[Stellar Plus][Feature] Upgrades to `@stellar/sdk` version `13.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hyperledger/cactus-test-tooling": "^2.0.0-rc.2",
         "@stellar/freighter-api": "^1.7.1",
-        "@stellar/stellar-sdk": "^12.2.0",
+        "@stellar/stellar-sdk": "^13.0.0",
         "axios": "^1.6.2",
         "uuid": "^9.0.1"
       },
@@ -2270,12 +2270,14 @@
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
-      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.0.tgz",
-      "integrity": "sha512-pWwn+XWP5NotmIteZNuJzHeNn9DYSqH3lsYbtFUoSYy1QegzZdi9D8dK6fJ2fpBAnf/rcDjHgHOw3gtHaQFVbg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+      "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
@@ -2285,21 +2287,34 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+        "sodium-native": "^4.3.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
+        "@stellar/stellar-base": "^13.0.1",
+        "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/axios": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -3246,6 +3261,8 @@
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6438,6 +6455,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -7751,6 +7777,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -11256,6 +11294,7 @@
     },
     "node_modules/pkcs11js": {
       "version": "1.3.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12540,8 +12579,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.1.1",
-      "hasInstallScript": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13528,6 +13568,8 @@
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
     },
     "node_modules/type": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@hyperledger/cactus-test-tooling": "^2.0.0-rc.2",
     "@stellar/freighter-api": "^1.7.1",
-    "@stellar/stellar-sdk": "^12.2.0",
+    "@stellar/stellar-sdk": "^13.0.0",
     "axios": "^1.6.2",
     "uuid": "^9.0.1"
   }

--- a/src/stellar-plus/core/contract-engine/errors.ts
+++ b/src/stellar-plus/core/contract-engine/errors.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
 
 import { StellarPlusError } from 'stellar-plus/error'
 

--- a/src/stellar-plus/core/contract-engine/index.ts
+++ b/src/stellar-plus/core/contract-engine/index.ts
@@ -6,7 +6,7 @@ import {
   Operation,
   OperationOptions,
   SorobanDataBuilder,
-  SorobanRpc as SorobanRpcNamespace,
+  rpc as SorobanRpcNamespace,
   xdr,
 } from '@stellar/stellar-sdk'
 import { Spec } from '@stellar/stellar-sdk/contract'

--- a/src/stellar-plus/core/contract-engine/index.unit.test.ts
+++ b/src/stellar-plus/core/contract-engine/index.unit.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { Asset, Contract, SorobanRpc, xdr } from '@stellar/stellar-sdk'
+import { Asset, Contract, rpc as SorobanRpc, xdr } from '@stellar/stellar-sdk'
 
 import { methods as tokenMethods, spec as tokenSpec } from 'stellar-plus/asset/soroban-token/constants'
 import { SorobanTransactionPipeline } from 'stellar-plus/core/pipelines/soroban-transaction'

--- a/src/stellar-plus/core/pipelines/simulate-transaction/errors.ts
+++ b/src/stellar-plus/core/pipelines/simulate-transaction/errors.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import { StellarPlusError } from 'stellar-plus/error'
 import { ConveyorBeltErrorMeta } from 'stellar-plus/error/helpers/conveyor-belt'

--- a/src/stellar-plus/core/pipelines/simulate-transaction/index.ts
+++ b/src/stellar-plus/core/pipelines/simulate-transaction/index.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import {
   SimulateTransactionPipelineInput,

--- a/src/stellar-plus/core/pipelines/simulate-transaction/index.unit.test.ts
+++ b/src/stellar-plus/core/pipelines/simulate-transaction/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { Account, SorobanDataBuilder, SorobanRpc, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
+import { Account, SorobanDataBuilder, rpc as SorobanRpc, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
 
 import { SimulateTransactionPipeline } from 'stellar-plus/core/pipelines/simulate-transaction'
 import { PSIError } from 'stellar-plus/core/pipelines/simulate-transaction/errors'

--- a/src/stellar-plus/core/pipelines/simulate-transaction/types.ts
+++ b/src/stellar-plus/core/pipelines/simulate-transaction/types.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
 
 import { TransactionResources } from 'stellar-plus/core/contract-engine/types'
 import { RpcHandler } from 'stellar-plus/rpc/types'

--- a/src/stellar-plus/core/pipelines/soroban-auth/index.unit.test.ts
+++ b/src/stellar-plus/core/pipelines/soroban-auth/index.unit.test.ts
@@ -1,4 +1,11 @@
-import { Account, SorobanDataBuilder, SorobanRpc, Transaction, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
+import {
+  Account,
+  SorobanDataBuilder,
+  rpc as SorobanRpc,
+  Transaction,
+  TransactionBuilder,
+  xdr,
+} from '@stellar/stellar-sdk'
 
 import { SimulateTransactionPipeline } from 'stellar-plus/core/pipelines/simulate-transaction'
 import { SorobanAuthPipeline } from 'stellar-plus/core/pipelines/soroban-auth'

--- a/src/stellar-plus/core/pipelines/soroban-auth/types.ts
+++ b/src/stellar-plus/core/pipelines/soroban-auth/types.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
 
 import { AccountHandler } from 'stellar-plus/account'
 import { RpcHandler } from 'stellar-plus/rpc/types'

--- a/src/stellar-plus/core/pipelines/soroban-get-transaction/errors.ts
+++ b/src/stellar-plus/core/pipelines/soroban-get-transaction/errors.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
 
 import { StellarPlusError } from 'stellar-plus/error'
 import { ConveyorBeltErrorMeta } from 'stellar-plus/error/helpers/conveyor-belt'

--- a/src/stellar-plus/core/pipelines/soroban-get-transaction/index.ts
+++ b/src/stellar-plus/core/pipelines/soroban-get-transaction/index.ts
@@ -1,4 +1,5 @@
-import { FeeBumpTransaction, SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { FeeBumpTransaction, rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import { extractConveyorBeltErrorMeta } from 'stellar-plus/error/helpers/conveyor-belt'
 import { ConveyorBelt } from 'stellar-plus/utils/pipeline/conveyor-belts'

--- a/src/stellar-plus/core/pipelines/soroban-get-transaction/index.unit.test.ts
+++ b/src/stellar-plus/core/pipelines/soroban-get-transaction/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { Account, SorobanRpc, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
+import { Account, rpc as SorobanRpc, TransactionBuilder, xdr } from '@stellar/stellar-sdk'
 
 import { SorobanGetTransactionPipeline } from 'stellar-plus/core/pipelines/soroban-get-transaction'
 import { SGTError } from 'stellar-plus/core/pipelines/soroban-get-transaction/errors'

--- a/src/stellar-plus/core/pipelines/soroban-get-transaction/types.ts
+++ b/src/stellar-plus/core/pipelines/soroban-get-transaction/types.ts
@@ -1,4 +1,4 @@
-import { FeeBumpTransaction, SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { FeeBumpTransaction, rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import { RpcHandler } from 'stellar-plus/rpc/types'
 import { BeltPluginType, GenericPlugin } from 'stellar-plus/utils/pipeline/conveyor-belts/types'

--- a/src/stellar-plus/core/pipelines/soroban-transaction/index.ts
+++ b/src/stellar-plus/core/pipelines/soroban-transaction/index.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
 
 import { BuildTransactionPipeline } from 'stellar-plus/core/pipelines/build-transaction'
 import {

--- a/src/stellar-plus/core/pipelines/submit-transaction/index.ts
+++ b/src/stellar-plus/core/pipelines/submit-transaction/index.ts
@@ -1,4 +1,4 @@
-import { FeeBumpTransaction, Horizon, SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { FeeBumpTransaction, Horizon, rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import {
   SubmitTransactionPipelineInput,

--- a/src/stellar-plus/core/pipelines/submit-transaction/index.unit.test.ts
+++ b/src/stellar-plus/core/pipelines/submit-transaction/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, TransactionBuilder } from '@stellar/stellar-sdk'
 
 import { SubmitTransactionPipeline } from 'stellar-plus/core/pipelines/submit-transaction'
 import {

--- a/src/stellar-plus/core/pipelines/submit-transaction/types.ts
+++ b/src/stellar-plus/core/pipelines/submit-transaction/types.ts
@@ -1,4 +1,4 @@
-import { FeeBumpTransaction, Horizon, SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { FeeBumpTransaction, Horizon, rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import { HorizonHandler } from 'stellar-plus'
 import { RpcHandler } from 'stellar-plus/rpc/types'

--- a/src/stellar-plus/error/helpers/soroban-rpc.ts
+++ b/src/stellar-plus/error/helpers/soroban-rpc.ts
@@ -1,4 +1,4 @@
-import { SorobanDataBuilder, SorobanRpc, xdr } from '@stellar/stellar-sdk'
+import { SorobanDataBuilder, rpc as SorobanRpc, xdr } from '@stellar/stellar-sdk'
 
 import { extractSorobanResultXdrOpErrorCode } from './result-meta-xdr'
 

--- a/src/stellar-plus/rpc/default-handler/index.ts
+++ b/src/stellar-plus/rpc/default-handler/index.ts
@@ -1,4 +1,4 @@
-import { FeeBumpTransaction, SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
+import { FeeBumpTransaction, rpc as SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
 
 import { DRHError } from 'stellar-plus/rpc/default-handler/errors'
 import { RpcHandler } from 'stellar-plus/rpc/types'

--- a/src/stellar-plus/rpc/default-handler/index.unit.test.ts
+++ b/src/stellar-plus/rpc/default-handler/index.unit.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { SorobanRpc, Transaction } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction } from '@stellar/stellar-sdk'
 
 import { CustomNet, TestNet } from 'stellar-plus/network'
 import { DRHError } from 'stellar-plus/rpc/default-handler/errors'

--- a/src/stellar-plus/rpc/types.ts
+++ b/src/stellar-plus/rpc/types.ts
@@ -1,4 +1,4 @@
-import { FeeBumpTransaction, SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
+import { FeeBumpTransaction, rpc as SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
 
 export type RpcHandler = {
   readonly type: 'RpcHandler'

--- a/src/stellar-plus/rpc/validation-cloud-handler/errors.ts
+++ b/src/stellar-plus/rpc/validation-cloud-handler/errors.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
 
 import { StellarPlusError } from 'stellar-plus/error'
 

--- a/src/stellar-plus/rpc/validation-cloud-handler/index.ts
+++ b/src/stellar-plus/rpc/validation-cloud-handler/index.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
 
-import { SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, Transaction, xdr } from '@stellar/stellar-sdk'
 import axios from 'axios'
 
 import { RpcHandler } from 'stellar-plus/rpc/types'

--- a/src/stellar-plus/rpc/validation-cloud-handler/types.ts
+++ b/src/stellar-plus/rpc/validation-cloud-handler/types.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc } from '@stellar/stellar-sdk'
 
 export type RequestPayload = {
   jsonrpc: string

--- a/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/auto-restore/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/auto-restore/index.ts
@@ -2,7 +2,7 @@ import {
   Account,
   Operation,
   SorobanDataBuilder,
-  SorobanRpc,
+  rpc as SorobanRpc,
   Transaction,
   TransactionBuilder,
 } from '@stellar/stellar-sdk'

--- a/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/extract-transaction-resources/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/extract-transaction-resources/index.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc, xdr } from '@stellar/stellar-sdk'
+import { rpc as SorobanRpc, xdr } from '@stellar/stellar-sdk'
 
 import { TransactionResources } from 'stellar-plus/core/contract-engine/types'
 import {
@@ -45,7 +45,7 @@ export class ExtractTransactionResourcesPlugin
 
     const resources: TransactionResources = {
       cpuInstructions: Number(sorobanTransactionData?.resources().instructions()),
-      ram: Number(simulatedTransaction.cost?.memBytes),
+      // ram: Number(simulatedTransaction.),
       minResourceFee: Number(simulatedTransaction.minResourceFee),
       ledgerReadBytes: sorobanTransactionData?.resources().readBytes(),
       ledgerWriteBytes: sorobanTransactionData?.resources().writeBytes(),


### PR DESCRIPTION
# What

Updates the `@stellar/stellar-sdk` version to version `13.0.0`

# Why

Stellar Upgraded their SDK and so as their RPC, and some events were not working for latest stellar version on `testnet` for testing `rust` contracts

# Checklist

- [x] Updates the libaray to the latest version
- [x] Fix all breaking changes
- [ ] Make tests work