### PR TITLE
fix: update ledgerReadBytes calculation to use diskReadBytes method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellar-plus",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellar-plus",
-      "version": "0.14.1",
+      "version": "0.14.3",
       "license": "ISC",
       "dependencies": {
         "@hyperledger/cactus-test-tooling": "^2.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-plus",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "beta version of stellar-plus, an all-in-one sdk for the Stellar blockchain",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/extract-transaction-resources/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/simulate-transaction/extract-transaction-resources/index.ts
@@ -47,7 +47,7 @@ export class ExtractTransactionResourcesPlugin
       cpuInstructions: Number(sorobanTransactionData?.resources().instructions()),
       ram: 0, //Number(simulatedTransaction.cost?.memBytes), //Review during refactor for v1
       minResourceFee: Number(simulatedTransaction.minResourceFee),
-      ledgerReadBytes: sorobanTransactionData?.resources().readBytes(),
+      ledgerReadBytes: sorobanTransactionData?.resources().diskReadBytes(),
       ledgerWriteBytes: sorobanTransactionData?.resources().writeBytes(),
       ledgerEntryReads: sorobanTransactionData?.resources().footprint().readOnly().length,
       ledgerEntryWrites: sorobanTransactionData?.resources().footprint().readWrite().length,


### PR DESCRIPTION
This pull request includes a version bump and a fix to the extraction of transaction resource data in the simulation pipeline. The main changes are:

Version update:

* Bumped the package version from `0.14.2` to `0.14.3` in `package.json` to reflect the new changes.

Bug fix / Resource extraction:

* Updated the extraction of ledger read bytes in `ExtractTransactionResourcesPlugin` to use `diskReadBytes()` instead of `readBytes()` for more accurate resource accounting. (`src/stellar-plus/utils/pipeline/plugins/simulate-transaction/extract-transaction-resources/index.ts`)