### PR TITLE
Fix V4 meta format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellar-plus",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellar-plus",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "ISC",
       "dependencies": {
         "@hyperledger/cactus-test-tooling": "^2.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-plus",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "beta version of stellar-plus, an all-in-one sdk for the Stellar blockchain",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-contract-id/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-contract-id/index.ts
@@ -25,9 +25,15 @@ export class ExtractContractIdPlugin
   ): Promise<SorobanGetTransactionPipelineOutput> {
     const { response, output } = item
 
-    const contractId = Address.fromScAddress(
-      response.resultMetaXdr.v3().sorobanMeta()?.returnValue().address() as xdr.ScAddress
-    ).toString()
+    let contractId: string
+
+    try {
+      contractId = Address.fromScAddress(
+        response.resultMetaXdr.v4().sorobanMeta()?.returnValue()?.address() as xdr.ScAddress
+      ).toString()
+    } catch (e) {
+      contractId = ''
+    }
 
     const pluginOutput: ContractIdOutput = {
       contractId,

--- a/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-invocation-output/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-invocation-output/index.ts
@@ -32,10 +32,15 @@ export class ExtractInvocationOutputPlugin<OutputType>
   ): Promise<SorobanGetTransactionPipelineOutput> {
     const { response, output }: SorobanGetTransactionPipelineOutput = item as SorobanGetTransactionPipelineOutput
 
-    const value = this.spec.funcResToNative(
-      this.method,
-      response.resultMetaXdr.v3().sorobanMeta()?.returnValue().toXDR('base64') as string
-    ) as unknown
+    let value: unknown
+    try {
+      value = this.spec.funcResToNative(
+        this.method,
+        response.resultMetaXdr.v4().sorobanMeta()?.returnValue()?.toXDR('base64') as string
+      ) as unknown
+    } catch (e) {
+      value = {}
+    }
 
     const pluginOutput: ContractInvocationOutput<string> = {
       value: String(value as OutputType),

--- a/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-wasm-hash/index.ts
+++ b/src/stellar-plus/utils/pipeline/plugins/soroban-get-transaction/extract-wasm-hash/index.ts
@@ -23,9 +23,12 @@ export class ExtractWasmHashPlugin
   ): Promise<SorobanGetTransactionPipelineOutput> {
     const { response, output } = item
 
-    const wasmHash = (response.resultMetaXdr.v3().sorobanMeta()?.returnValue().value() as Buffer).toString(
-      'hex'
-    ) as string
+    let wasmHash: string
+    try {
+      wasmHash = (response.resultMetaXdr.v4().sorobanMeta()?.returnValue()?.value() as Buffer).toString('hex') as string
+    } catch (e) {
+      wasmHash = ''
+    }
 
     const pluginOutput: ContractWasmHashOutput = {
       wasmHash,


### PR DESCRIPTION
This pull request updates the SDK version and improves error handling and compatibility with Soroban v4 metadata in several pipeline plugins. The main focus is to ensure that the extraction of contract IDs, invocation outputs, and WASM hashes from transaction responses is robust and does not break if the expected data is missing or if the response format changes.

**Error handling and Soroban v4 compatibility improvements:**

* Updated all plugins (`extract-contract-id`, `extract-invocation-output`, `extract-wasm-hash`) to use `resultMetaXdr.v4()` instead of `v3()` for extracting Soroban metadata, ensuring compatibility with the latest Soroban version. Added try/catch blocks to gracefully handle missing or malformed data, returning default values when extraction fails. [[1]](diffhunk://#diff-06960bf2f983491c5df58ff55a36228ded4cecd46cf874caa57e36a5ad40eab1L28-R36) [[2]](diffhunk://#diff-eb0a31ffa8c21abf752d3fe79c708448e361e88ebf6b5fbb1d277af565341465L35-R43) [[3]](diffhunk://#diff-48585563b26754ccfba8b67bfad96a7e020d08b3cc065f7cdfcaffbe9e788d50L26-R31)

**Versioning:**

* Bumped the package version from `0.14.3` to `0.14.4` in `package.json` to reflect these changes.